### PR TITLE
Add option to make stickTo use either 0 or previous transpose value (…

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -286,7 +286,7 @@
     }
 
     let autoRegion = (left, right, opts = undefined) => {
-        let stickTo = opts?.stickTo
+        let stickTo = settings.stickyAutoTransposition ? opts?.stickTo : 0
         let skipSave = opts?.skipSave ?? false
         let ignorePrevious = opts?.ignorePrevious ?? false
     
@@ -389,7 +389,7 @@
         for (let region of regions) {
             // console.log('transposing region', region.left, region.right)
             let best = autoRegion(region.left, region.right, { 
-                stickTo: previous_transposition, 
+                stickTo: previous_transposition,
                 skipSave: true,
             })
             previous_transposition = best

--- a/src/components/SheetOptions.svelte
+++ b/src/components/SheetOptions.svelte
@@ -26,6 +26,7 @@
         minSpeedChange: 10,
         oorSeparator: ':',
         resilience: 2,
+        stickyAutoTransposition: false,
         font: fonts[0],
         lineHeight: 135,
         capturingImage: false,
@@ -45,6 +46,12 @@
                for="atleast">Resilience (?):</label>
         <input class="w-32" id="atleast" type="range" min=0 max=12 bind:value={settings.resilience}>
         <span style="display:flex; align-items: center">{settings.resilience}</span>
+    </div>
+    <div class="flex flex-row mt-3">
+        <label class="flex flex-row items-center"
+               title="Defines whether or not the transposed region(s) should be related to previous regions"
+               for="atleast">Sticky auto-transposition (?):</label>
+        <input class="mx-1" type='checkbox' id="sticky-auto-transposition" bind:checked={settings.stickyAutoTransposition}>
     </div>
 </div>
 

--- a/src/components/SheetOptions.svelte
+++ b/src/components/SheetOptions.svelte
@@ -50,7 +50,7 @@
     <div class="flex flex-row mt-3">
         <label class="flex flex-row items-center"
                title="Defines whether or not the transposed region(s) should be related to previous regions"
-               for="atleast">Sticky auto-transposition (?):</label>
+               for="sticky-auto-transposition">Sticky auto-transposition (?):</label>
         <input class="mx-1" type='checkbox' id="sticky-auto-transposition" bind:checked={settings.stickyAutoTransposition}>
     </div>
 </div>


### PR DESCRIPTION
In some cases, stickTo = 0 for all chords is much better for some music. This allows the option of whether or not autoRegion should transpose based on previous regions.

Feel free to change around the naming, definition, or default state.