### PR TITLE
fix incorrect single quote placement for text oor notation from last major update

### DIFF
--- a/src/utils/Rendering.js
+++ b/src/utils/Rendering.js
@@ -100,9 +100,9 @@ function render_chord(chord, next, settings, selected) {
         
         if (draw_as_oor === true) {
             let nonOors = chord.notes.filter(note => note.outOfRange === false)
-            let startOors = chord.notes.filter(note => note.outOfRange === true)
-            let endOors = chord.notes.filter(note => note.outOfRange === true)
-        
+            let startOors = chord.notes.filter(note => note.outOfRange === true && note.displayValue === note.value - 1024)
+            let endOors = chord.notes.filter(note => note.outOfRange === true && note.displayValue === note.value + 1024)
+
             const isFirstStartOor = (note === startOors[0])
             const isLastStartOor = (note === startOors[startOors.length-1])
             const isFirstEndOorWithoutChord = !isChord && note === endOors[0];


### PR DESCRIPTION
This fixes the placement of the single quote mark, we unfortunately missed something small in the code in the last major update.

Current:
![image](https://github.com/user-attachments/assets/e573074b-a603-44b9-91ca-b72c276a538b)

Corrected:
![image](https://github.com/user-attachments/assets/ea62e244-2664-4db7-9c49-6f19a4b2c0fb)
