### PR TITLE
Copy selection of text and transposes

### DIFF
--- a/public/global.css
+++ b/public/global.css
@@ -13,6 +13,7 @@ body {
 	margin: 0;
 	box-sizing: border-box;
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	user-select: none;
 }
 
 a {
@@ -85,4 +86,8 @@ button:hover {
   border-radius: 10px;
   -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.3);
   background-color: gray;
+}
+
+.app-background-color {
+	background: rgb(45, 42, 50);
 }

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -103,6 +103,13 @@
     let container
 
     document.addEventListener("copy", handleCopy);
+    document.addEventListener('keydown', (e) => {
+        // TODO: ctrl + a is causing out of range separator input text to be selected from the sidebar, sheet text should only ever get selected
+        const activeElIsComment = document.activeElement.classList.contains("comment")
+        if (!activeElIsComment && e.ctrlKey && e.key.toLowerCase() === "a") {
+            e.preventDefault();
+        }
+    });
     document.addEventListener("selectionchange", handleNativeSelection)
 
     async function onFileChange() {

--- a/src/components/SheetActions.svelte
+++ b/src/components/SheetActions.svelte
@@ -6,7 +6,7 @@
     let dispatch = createEventDispatcher()
 </script>
 
-<div class="flex flex-row gap-1">
+<div class="flex flex-row gap-1 sticky top-0 z-10 app-background-color">
     <button on:click={ () => dispatch("copyText") }>Copy Text</button>
 
     <button disabled={settings.capturingImage} on:click={() => dispatch("captureSheetAsImage", {mode: "download"})}>

--- a/src/components/SheetOptions.svelte
+++ b/src/components/SheetOptions.svelte
@@ -241,10 +241,6 @@
 </div>
 
 <style>
-    * {
-        user-select: none;
-    }
-
     label {
         max-width: fit-content;
         text-align: center;
@@ -262,6 +258,7 @@
         margin-left: 0.4em;
         margin-top: 0.2em;
         margin-bottom: 0;
+        user-select: none;
     }
 
     select option {
@@ -285,6 +282,7 @@
 
     input[type="text"] {
         margin-bottom: 0;
+        user-select: none;
     }
 
     .beats, .select-label, .tempo {


### PR DESCRIPTION
As it says in the title, allows you to copy transposes from selected lines, and allows you to copy any sheet text with the native window selection, making sure that ctrl + c or clicking copy text will filter that text like previously.

To support the UX for this feature more, I made the top tool bar sticky, and adding title now causes the page to scroll to the top.