### PR TITLE
Fixes edge cases found with PR #27 (Selecting notes image capture)

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -721,20 +721,45 @@
 
       // Backtrack to include header comments (e.g. Transpose by ...)
       let scan = start - 1;
+      let transposeFound = false;
       while (scan >= 0) {
         let item = chords_and_otherwise[scan];
         if (item.type == "comment" && item.kind != "inline") {
+          if (item.kind == "transpose") {
+            if (transposeFound) break;
+            transposeFound = true;
+          }
           start = scan;
+          scan--;
+        } else if (item.type == "break") {
           scan--;
         } else {
           break;
         }
       }
 
-      // Check if we have a transpose above the first line in the selection, if not, find the previous one
+      // Find the first chord in the selection to determine if it has a governing header
+      let firstChordIndex = -1;
+      for (let i = start; i <= end; i++) {
+        if (!not_chord(chords_and_otherwise[i])) {
+          firstChordIndex = i;
+          break;
+        }
+      }
+
+      // If no chord found, effectively the range is the whole selection
+      let checkLimit = firstChordIndex !== -1 ? firstChordIndex : end;
+
+      let hasGoverningTranspose = false;
+      for (let i = start; i <= checkLimit; i++) {
+        if (chords_and_otherwise[i].kind === "transpose") {
+          hasGoverningTranspose = true;
+          break;
+        }
+      }
+
       let extraTransposeIndex = -1;
-      let firstItem = chords_and_otherwise[start];
-      if (firstItem.kind !== "transpose") {
+      if (!hasGoverningTranspose) {
         let backScan = start - 1;
         while (backScan >= 0) {
           let item = chords_and_otherwise[backScan];


### PR DESCRIPTION
Edge Cases (2):

1. Included an irrelevant transpose comment due to a regular comment being in the previous transpose before the selected transpose section.

Before:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/7567d0a0-06a1-484c-b7aa-4873f4a32b71" />
After:
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/fbd3aa7d-1933-498d-923e-e0b4d9c6d54b" />

2. If the selected notes include the first line of the sheet, and there is a title, the title wasn't included in the image

