### PR TITLE
Combining sheet text/images/transposes + some other bits and bobs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "date-fns": "^3.6.0",
+        "image-stitch": "^1.1.53",
         "midi-file": "^1.2.4",
         "midi-json-parser": "^8.1.18",
         "midi-parser-js": "^4.0.4",
@@ -318,6 +319,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
       "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true
+    },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -1266,6 +1272,36 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/image-stitch": {
+      "version": "1.1.53",
+      "resolved": "https://registry.npmjs.org/image-stitch/-/image-stitch-1.1.53.tgz",
+      "integrity": "sha512-N9EkYnwDt7bb4QbfZ1dUurQIU/SsEWDP1rF3CiopYvjgOafkDpu6zQmcsJPsPZSWDxA8L66UJTSHdrBCF0T0pA==",
+      "dependencies": {
+        "@types/pako": "^2.0.4",
+        "jpeg-encoder-wasm": "github:jburnhams/jpeg-encoder#9267440ca1bd050e198fb05aab36beee1a32a458",
+        "jpeg-js": "^0.4.4",
+        "pako": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "heic-decode": "^2.0.0",
+        "libheif-js": "^1.17.0",
+        "sharp": "^0.33.0"
+      },
+      "peerDependenciesMeta": {
+        "heic-decode": {
+          "optional": true
+        },
+        "libheif-js": {
+          "optional": true
+        },
+        "sharp": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -1456,6 +1492,17 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/jpeg-encoder-wasm": {
+      "version": "0.1.0",
+      "resolved": "git+ssh://git@github.com/jburnhams/jpeg-encoder.git#9267440ca1bd050e198fb05aab36beee1a32a458",
+      "integrity": "sha512-gn1v8LIEM2sGjytLbcq+TsqkCFNKBHBxNKLxpxFhNF2c2Aw3SV35eSTiiFV3tFoAEWpEbODe8UGYAohpEW9ALA==",
+      "license": "ISC"
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4084,6 +4131,11 @@
       "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true
     },
+    "@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw=="
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -4766,6 +4818,17 @@
       "dev": true,
       "requires": {}
     },
+    "image-stitch": {
+      "version": "1.1.53",
+      "resolved": "https://registry.npmjs.org/image-stitch/-/image-stitch-1.1.53.tgz",
+      "integrity": "sha512-N9EkYnwDt7bb4QbfZ1dUurQIU/SsEWDP1rF3CiopYvjgOafkDpu6zQmcsJPsPZSWDxA8L66UJTSHdrBCF0T0pA==",
+      "requires": {
+        "@types/pako": "^2.0.4",
+        "jpeg-encoder-wasm": "github:jburnhams/jpeg-encoder#9267440ca1bd050e198fb05aab36beee1a32a458",
+        "jpeg-js": "^0.4.4",
+        "pako": "^2.1.0"
+      }
+    },
     "import-cwd": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
@@ -4914,6 +4977,16 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
       "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
       "dev": true
+    },
+    "jpeg-encoder-wasm": {
+      "version": "git+ssh://git@github.com/jburnhams/jpeg-encoder.git#9267440ca1bd050e198fb05aab36beee1a32a458",
+      "integrity": "sha512-gn1v8LIEM2sGjytLbcq+TsqkCFNKBHBxNKLxpxFhNF2c2Aw3SV35eSTiiFV3tFoAEWpEbODe8UGYAohpEW9ALA==",
+      "from": "jpeg-encoder-wasm@github:jburnhams/jpeg-encoder#9267440ca1bd050e198fb05aab36beee1a32a458"
+    },
+    "jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "date-fns": "^3.6.0",
+    "image-stitch": "^1.1.53",
     "midi-file": "^1.2.4",
     "midi-json-parser": "^8.1.18",
     "midi-parser-js": "^4.0.4",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1040,6 +1040,93 @@
     updateChords();
   }
 
+  // URL Params
+  {
+    const urlParams = new URLSearchParams(window.location.search);
+    const openSheet = urlParams.get("open");
+
+    if (openSheet) {
+      const decodedName = decodeURIComponent(openSheet);
+
+      // Timeout to ensure DOM is ready
+      setTimeout(() => {
+        pieces = history.getAll();
+        const piece = pieces.find((p) => p.name === decodedName);
+
+        if (piece) {
+          filename = decodedName;
+          existingProject.setAndProceed(piece);
+          if (importer.element) importer.hide();
+        } else {
+          console.warn("Could not find sheet with name:", decodedName);
+          alert(`Could not find sheet "${decodedName}".`);
+        }
+      }, 1);
+    }
+  }
+
+  function splitSheet() {
+    if (!has_selection) return;
+
+    let start = real_index_of(selection.left);
+    let end = real_index_of(selection.right);
+
+    // Backtrack to include preceding comments
+    let scan = start - 1;
+    while (scan >= 0) {
+      let item = chords_and_otherwise[scan];
+      if (item.type == "comment" && item.kind != "inline") {
+        start = scan;
+        scan--;
+      } else if (item.type == "break") {
+        scan--;
+      } else {
+        break;
+      }
+    }
+
+    let newName = prompt("Enter a name for the new sheet:", "");
+    if (!newName) return;
+
+    const exists = history.getAll().some((entry) => entry.name === newName);
+    if (exists) {
+      alert(
+        "A sheet with this name already exists. Please choose a different name.",
+      );
+      return;
+    }
+
+    // Open new tab for the split sheet
+    const newWindow = window.open("", "_blank");
+
+    let items = JSON.parse(
+      JSON.stringify(chords_and_otherwise.slice(start, end + 1)),
+    );
+
+    // Remove selection markers and re-index chords
+    let newIndex = 0;
+    items.forEach((item) => {
+      if (item.selected) delete item.selected;
+      if (is_chord(item)) {
+        item.index = newIndex++;
+      }
+    });
+
+    history.add(newName, settings, items).then(() => {
+      pieces = history.getAll((remaining = remainingSize()));
+      // Open in new tab
+      const url = new URL(window.location.href);
+      url.searchParams.set("open", newName);
+
+      if (newWindow) {
+        newWindow.location.href = url.toString();
+      } else {
+        // Fallback if window failed to open (rare if triggered by click)
+        window.open(url.toString(), "_blank");
+      }
+    });
+  }
+
   function joinRegion(left, right) {
     let start = real_index_of(left);
 
@@ -1486,6 +1573,7 @@ Individual sizes are an estimation, the total is correct.">ⓘ</span
           renderSelection();
           window.scroll(0, 0);
         }}
+        on:splitSheet={splitSheet}
       />
 
       <div

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -721,20 +721,45 @@
 
       // Backtrack to include header comments (e.g. Transpose by ...)
       let scan = start - 1;
+      let transposeFound = false;
       while (scan >= 0) {
         let item = chords_and_otherwise[scan];
         if (item.type == "comment" && item.kind != "inline") {
+          if (item.kind == "transpose") {
+            if (transposeFound) break;
+            transposeFound = true;
+          }
           start = scan;
+          scan--;
+        } else if (item.type == "break") {
           scan--;
         } else {
           break;
         }
       }
 
-      // Check if we have a transpose above the first line in the selection, if not, find the previous one
+      // Find the first chord in the selection to determine if it has a governing header
+      let firstChordIndex = -1;
+      for (let i = start; i <= end; i++) {
+        if (!not_chord(chords_and_otherwise[i])) {
+          firstChordIndex = i;
+          break;
+        }
+      }
+
+      // If no chord found, effectively the range is the whole selection
+      let checkLimit = firstChordIndex !== -1 ? firstChordIndex : end;
+
+      let hasGoverningTranspose = false;
+      for (let i = start; i <= checkLimit; i++) {
+        if (chords_and_otherwise[i].kind === "transpose") {
+          hasGoverningTranspose = true;
+          break;
+        }
+      }
+
       let extraTransposeIndex = -1;
-      let firstItem = chords_and_otherwise[start];
-      if (firstItem.kind !== "transpose") {
+      if (!hasGoverningTranspose) {
         let backScan = start - 1;
         while (backScan >= 0) {
           let item = chords_and_otherwise[backScan];

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,7 +15,12 @@
     not_chord,
     index_of_index,
   } from "./utils/VP.js";
-  let real_index_of = (x) => index_of_index(chords_and_otherwise, x);
+  let real_index_of = (x) => {
+    const result = index_of_index(chords_and_otherwise, x);
+    if (result !== undefined) return result;
+    // Fallback for split sheets or edge cases where binary search fails
+    return chords_and_otherwise?.findIndex((e) => e.index === x) ?? -1;
+  };
   let chord_at = (x) => chords_and_otherwise[real_index_of(x)];
 
   import SheetOptions from "./components/SheetOptions.svelte";

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1470,21 +1470,6 @@
 
   {#if pieces.length > 0}
     <!-- Has piece(s) in history? -->
-    <button
-      disabled={pieces.length < 1}
-      class="p-2 border rounded transition-colors {isHistoryMultiSelect
-        ? 'text-white border-white'
-        : ''}"
-      on:click={() => {
-        isHistoryMultiSelect = !isHistoryMultiSelect;
-        if (!isHistoryMultiSelect) {
-          selectedSheets = [];
-          HistoryCombineDialogComp.resetSettings();
-        }
-      }}
-    >
-      {isHistoryMultiSelect ? "Cancel Selection" : "Combine"}
-    </button>
     <hr class="w-[58em]" style="border: 1px solid #a0a0a0" />
 
     <div class="flex flex-col items-center gap-6">
@@ -1497,13 +1482,6 @@
           </p>
         {/if}
       </div>
-
-      <HistoryCombineDialog
-        appSettings={settings}
-        bind:combineSelection={selectedSheets}
-        bind:this={HistoryCombineDialogComp}
-        on:command={handleHistoryCombineCommand}
-      />
 
       <HistoryList
         {pieces}
@@ -1519,7 +1497,30 @@
         }}
         on:export={(e) => downloadSheetData(e.detail.project)}
       />
+
+      <HistoryCombineDialog
+        appSettings={settings}
+        bind:combineSelection={selectedSheets}
+        bind:this={HistoryCombineDialogComp}
+        on:command={handleHistoryCombineCommand}
+      />
     </div>
+
+    <button
+      disabled={pieces.length < 1}
+      class="!p-2 border rounded transition-colors {isHistoryMultiSelect
+        ? 'text-white border-white'
+        : ''}"
+      on:click={() => {
+        isHistoryMultiSelect = !isHistoryMultiSelect;
+        if (!isHistoryMultiSelect) {
+          selectedSheets = [];
+          HistoryCombineDialogComp.resetSettings();
+        }
+      }}
+    >
+      {isHistoryMultiSelect ? "Cancel selection" : "Combine multiple sheets"}
+    </button>
 
     <div>
       <StorageIndicator used={remaining} />

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -908,6 +908,18 @@
   }
 
   function copyCapturedImage(blob) {
+    // Prevent browser crash (RESULT_CODE_KILLED_BAD_MESSAGE) for very large images
+    // Chromium for example has IPC limits for clipboard payload.
+    const MAX_COPY_SIZE = 8 * 1024 * 1024; // 8MB (should be ok?)
+    if (blob.size > MAX_COPY_SIZE) {
+      addToast(
+        `Image is too large to copy (${(blob.size / 1024 / 1024).toFixed(1)}MB). Downloading instead.`,
+        "warning",
+      );
+      downloadCapturedImage(blob, "large_sheet");
+      return;
+    }
+
     // note: ClipboardItem is not supported by mozilla
     try {
       navigator.clipboard.write([
@@ -1459,7 +1471,7 @@
   {#if pieces.length > 0}
     <!-- Has piece(s) in history? -->
     <button
-      disabled={pieces.length < 2}
+      disabled={pieces.length < 1}
       class="p-2 border rounded transition-colors {isHistoryMultiSelect
         ? 'text-white border-white'
         : ''}"
@@ -1719,7 +1731,7 @@
             {#if inner.type}
               {@const next_thing = chords_and_otherwise[+index + 1]}
               {@const previous_thing = chords_and_otherwise[+index - 1]}
-              {#if inner.type === "break" && next_thing.type != "comment" && previous_thing?.type != "comment"}
+              {#if inner.type === "break" && next_thing?.type != "comment" && previous_thing?.type != "comment"}
                 <br data-index={index} class="sheet-item" />
               {:else if inner.type === "comment"}
                 {#if index > 0 && previous_thing?.type != "comment" && inner.notop != true && inner.kind != "inline"}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -52,6 +52,10 @@
   import SheetActions from "./components/SheetActions.svelte";
   import Guide from "./components/Guide.svelte";
   import ChordEditor from "./components/ChordEditor.svelte";
+  import HistoryCombineDialog from "./components/HistoryCombineDialog.svelte";
+  import HistoryList from "./components/HistoryList.svelte";
+  import { handleHistoryCombineCommand as handleHistoryCombineCommandUtils } from "./utils/HistoryCombine.js";
+  import { setGlobalContext } from "./utils/GlobalContext.js";
 
   let existingProject = {
     element: undefined,
@@ -138,10 +142,47 @@
     }, 20);
   }
 
+  // --- Global Context Initialization ---
+  const context = {
+    get importer() {
+      return importer;
+    },
+    setIsHistoryMultiSelect: (v) => (isHistoryMultiSelect = v),
+    setSheetReady: (v) => (sheetReady = v),
+    getSettings: () => settings,
+    updateSettings: (updates) => (settings = { ...settings, ...updates }),
+    getSelectedSheets: () => selectedSheets,
+    setSelectedSheets: (v) => (selectedSheets = v),
+    get HistoryCombineDialogComp() {
+      return HistoryCombineDialogComp;
+    },
+    getContainer: () => container,
+    getChordsAndOtherwise: () => chords_and_otherwise,
+    setChordsAndOtherwise: (v) => (chords_and_otherwise = v),
+    getFilename: () => filename,
+    setFilename: (v) => (filename = v),
+    getSheetReady: () => sheetReady,
+    copyCapturedImage,
+    downloadCapturedImage,
+  };
+  setGlobalContext(context);
+  // -------------------------------------
+
   let MIDIObject;
   let tracks;
 
   let chords_and_otherwise;
+
+  let isHistoryMultiSelect = false;
+  let selectedSheets = [];
+  let HistoryCombineDialogComp; // will be bound to HistoryCombineDialog component
+
+  /**
+   * Helper for the HistoryCombine utility to load a sheet and wait for layout.
+   */
+  async function handleHistoryCombineCommand(e) {
+    await handleHistoryCombineCommandUtils(e);
+  }
 
   let container;
 
@@ -851,8 +892,8 @@
     }
   }
 
-  function downloadCapturedImage(blob) {
-    download(blob, "png");
+  function downloadCapturedImage(blob, name = undefined) {
+    download(blob, "png", name);
   }
 
   function downloadSheetData(piece) {
@@ -861,10 +902,10 @@
     download(blob, "json");
   }
 
-  function download(blob, extension) {
+  function download(blob, extension, name = undefined) {
     const url = URL.createObjectURL(blob);
 
-    let output = `${filename}.${extension}`;
+    let output = `${name ?? filename}.${extension}`;
 
     // create a temporary element to download the data
     let linkEl = document.createElement("a");
@@ -1336,10 +1377,7 @@
       on:drop|preventDefault={droppedFile}
       on:dragover|preventDefault
       for="drop"
-      class="cursor-pointer
-                                 rounded-xl
-                                 text-xl
-                                 p-4"
+      class="cursor-pointer rounded-xl text-xl p-4"
       style="border: 2px solid dimgrey"
     >
       Click or drop a MIDI/JSON file here!
@@ -1356,34 +1394,53 @@
 
   {#if pieces.length > 0}
     <!-- Has piece(s) in history? -->
+    <button
+      disabled={pieces.length < 2}
+      class="p-2 border border-white rounded hover:bg-white hover:text-black transition-colors"
+      on:click={() => {
+        isHistoryMultiSelect = !isHistoryMultiSelect;
+        if (!isHistoryMultiSelect) {
+          selectedSheets = [];
+          HistoryCombineDialogComp.resetSettings();
+        }
+      }}
+    >
+      {isHistoryMultiSelect ? "Cancel Selection" : "Combine"}
+    </button>
     <hr class="w-[58em]" style="border: 1px solid #a0a0a0" />
 
     <div class="flex flex-col items-center gap-6">
-      {#if pieces.length == 1 && pieces[0].name.endsWith("(sample)")}
-        <p class="text-white text-3xl">Or, try this sample piece:</p>
-      {:else}
-        <p class="text-white text-3xl">
-          Or, continue one of your previous projects:
-        </p>
-      {/if}
-      <div
-        class="w-3/4 flex flex-wrap justify-center gap-2 overflow-clip text-ellipsis"
-      >
-        {#each pieces as piece}
-          <HistoryEntry
-            {piece}
-            on:load={(x) => {
-              existingProject.setAndProceed(x.detail.project);
-              importer.hide();
-            }}
-            on:refresh={() => {
-              pieces = history.getAll();
-              remaining = remainingSize();
-            }}
-            on:export={() => downloadSheetData(piece)}
-          />
-        {/each}
+      <div class="flex flex-row gap-4 items-center">
+        {#if pieces.length == 1 && pieces[0].name.endsWith("(sample)")}
+          <p class="text-white text-3xl">Or, try this sample piece:</p>
+        {:else}
+          <p class="text-white text-3xl">
+            Or, continue one of your previous projects:
+          </p>
+        {/if}
       </div>
+
+      <HistoryCombineDialog
+        {settings}
+        bind:selectedSheets
+        bind:this={HistoryCombineDialogComp}
+        on:command={handleHistoryCombineCommand}
+      />
+
+      <HistoryList
+        {pieces}
+        selectable={isHistoryMultiSelect}
+        bind:selectedSheets
+        on:load={(e) => {
+          existingProject.setAndProceed(e.detail.project);
+          importer.hide();
+        }}
+        on:refresh={() => {
+          pieces = history.getAll();
+          remaining = remainingSize();
+        }}
+        on:export={(e) => downloadSheetData(e.detail.project)}
+      />
     </div>
 
     <div>
@@ -1600,7 +1657,7 @@ Individual sizes are an estimation, the total is correct.">ⓘ</span
               {#if inner.type === "break" && next_thing.type != "comment" && previous_thing?.type != "comment"}
                 <br data-index={index} class="sheet-item" />
               {:else if inner.type === "comment"}
-                {#if previous_thing?.type != "comment" && inner.notop != true && inner.kind != "inline"}
+                {#if index > 0 && previous_thing?.type != "comment" && inner.notop != true && inner.kind != "inline"}
                   <br data-index={index} class="sheet-item" />
                 {/if}
                 {#if ["custom", "tempo", "inline", "title"].includes(inner.kind)}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1192,19 +1192,45 @@
       }
     });
 
-    history.add(newName, settings, items).then(() => {
-      pieces = history.getAll((remaining = remainingSize()));
-      // Open in new tab
-      const url = new URL(window.location.href);
-      url.searchParams.set("open", newName);
+    history
+      .add(newName, settings, items, false, { noAutoDelete: true })
+      .then(() => {
+        pieces = history.getAll((remaining = remainingSize()));
+        // Open in new tab
+        const url = new URL(window.location.href);
+        url.searchParams.set("open", newName);
 
-      if (newWindow) {
-        newWindow.location.href = url.toString();
-      } else {
-        // Fallback if window failed to open (rare if triggered by click)
-        window.open(url.toString(), "_blank");
-      }
-    });
+        if (newWindow) {
+          newWindow.location.href = url.toString();
+        } else {
+          // Fallback if window failed to open (rare if triggered by click)
+          window.open(url.toString(), "_blank");
+        }
+      })
+      .catch((e) => {
+        if (newWindow) newWindow.close();
+
+        const errorMsg = e.message || "";
+        const isQuotaError =
+          e.name === "QuotaExceededError" ||
+          e.code === 22 ||
+          e.code === 1014 ||
+          errorMsg.includes("QuotaExceededError") ||
+          errorMsg.includes("The quota has been exceeded.") ||
+          errorMsg.includes("NS_ERROR_DOM_QUOTA_REACHED");
+
+        if (isQuotaError) {
+          if (
+            confirm("Storage is full, unable to save. Open in current window?")
+          ) {
+            filename = newName;
+            chords_and_otherwise = items;
+            softRegen();
+          }
+        } else {
+          addToast("Failed to split sheet: " + errorMsg, "error");
+        }
+      });
   }
 
   function joinRegion(left, right) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1679,6 +1679,9 @@
       <SheetActions
         {settings}
         hasSelection={has_selection}
+        isAllNotesSelected={selection.left === 0 &&
+          selection.right ===
+            chords_and_otherwise[chords_and_otherwise.length - 1].index}
         on:captureSheetAsImage={(event) => {
           captureSheetAsImage(event.detail.mode, event.detail.selectionOnly);
         }}

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1434,7 +1434,9 @@
     <!-- Has piece(s) in history? -->
     <button
       disabled={pieces.length < 2}
-      class="p-2 border border-white rounded hover:bg-white hover:text-black transition-colors"
+      class="p-2 border rounded transition-colors {isHistoryMultiSelect
+        ? 'text-white border-white'
+        : ''}"
       on:click={() => {
         isHistoryMultiSelect = !isHistoryMultiSelect;
         if (!isHistoryMultiSelect) {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { tick } from "svelte";
   import { domToBlob } from "modern-screenshot";
   import {
     getMIDIFileFromArrayBuffer,
@@ -165,6 +166,10 @@
     getFilename: () => filename,
     setFilename: (v) => (filename = v),
     getSheetReady: () => sheetReady,
+    addToast,
+    softRegen,
+    tick,
+    setForcedNextSheetStartTime: (v) => (forcedNextSheetStartTime = v),
     copyCapturedImage,
     downloadCapturedImage,
   };
@@ -178,6 +183,7 @@
 
   let isHistoryMultiSelect = false;
   let selectedSheets = [];
+  let forcedNextSheetStartTime = undefined;
   let HistoryCombineDialogComp; // will be bound to HistoryCombineDialog component
 
   /**
@@ -334,10 +340,25 @@
           not_chord,
           real_index_of(chord.index + 1),
         );
-        if (!next_valid_chord) next_valid_chord = chord;
-        new_chord.next = {
-          notes: [{ playTime: next_valid_chord.notes[0].playTime }],
-        };
+
+        if (!next_valid_chord) {
+          if (forcedNextSheetStartTime !== undefined) {
+            // adjusts timing between for each combined sheet (except the last)
+            new_chord.next = {
+              notes: [{ playTime: forcedNextSheetStartTime }],
+            };
+          } else {
+            // original behavior
+            next_valid_chord = chord;
+            new_chord.next = {
+              notes: [{ playTime: next_valid_chord.notes[0].playTime }],
+            };
+          }
+        } else {
+          new_chord.next = {
+            notes: [{ playTime: next_valid_chord.notes[0].playTime }],
+          };
+        }
         if ("reflow" in chord) new_chord.reflow = chord.reflow;
 
         // new_note = new_note.sort((a, b) => a.displayValue - b.displayValue);
@@ -1438,8 +1459,8 @@
       </div>
 
       <HistoryCombineDialog
-        {settings}
-        bind:selectedSheets
+        appSettings={settings}
+        bind:combineSelection={selectedSheets}
         bind:this={HistoryCombineDialogComp}
         on:command={handleHistoryCombineCommand}
       />
@@ -1716,7 +1737,14 @@
                 {/if}
                 {#if inner.kind != "inline"}
                   <!-- and is any comment, break after -->
-                  <br data-index={index} class="sheet-item" />
+                  <br
+                    data-index={index}
+                    class="sheet-item"
+                    style={settings.capturingImage &&
+                    index === chords_and_otherwise.length - 1
+                      ? "display:none"
+                      : ""}
+                  />
                 {/if}
               {/if}
             {:else}

--- a/src/components/HistoryCombineDialog.svelte
+++ b/src/components/HistoryCombineDialog.svelte
@@ -4,28 +4,36 @@
 
   const dispatch = createEventDispatcher();
 
-  export let selectedSheets = [];
-  export let settings = {}; // Current app settings to initialize defaults
+  export let combineSelection = [];
+  export let appSettings = {};
 
   let historyCombineDialog;
   let busy = false;
   let tempSettings = {};
 
-  // Initialize tempSettings when settings prop changes or on mount
-  $: if (settings && Object.keys(tempSettings).length === 0) {
-    tempSettings = { ...settings };
+  // Initialize tempSettings from appSettings if not yet set
+  $: if (appSettings && Object.keys(tempSettings).length === 0) {
+    tempSettings = { ...appSettings };
+  }
+
+  export function setBusy(val) {
+    busy = val;
+  }
+
+  export function resetSettings() {
+    tempSettings = { ...appSettings };
   }
 
   function move(index, direction) {
     if (busy) return;
-    const newItems = [...selectedSheets];
+    const newItems = [...combineSelection];
     const targetIndex = index + direction;
     if (targetIndex < 0 || targetIndex >= newItems.length) return;
 
     const temp = newItems[index];
     newItems[index] = newItems[targetIndex];
     newItems[targetIndex] = temp;
-    selectedSheets = newItems;
+    combineSelection = newItems;
   }
 
   export function showModal() {
@@ -37,15 +45,15 @@
   }
 </script>
 
-{#if selectedSheets.length > 0}
+{#if combineSelection.length > 0}
   <div
     class="flex flex-col items-center gap-2 p-4 border border-gray-600 rounded-lg bg-gray-800"
   >
     <h3 class="text-xl text-white">
-      Selected Sheets ({selectedSheets.length})
+      Selected Sheets ({combineSelection.length})
     </h3>
     <div class="flex flex-col gap-1 w-full relative">
-      {#each selectedSheets as sheet, i (sheet.name)}
+      {#each combineSelection as sheet, i (sheet.name)}
         <div
           class="flex items-center justify-between text-white p-2 bg-gray-700 rounded gap-2"
         >
@@ -60,7 +68,7 @@
             </button>
             <button
               class="px-2 py-0.5 bg-gray-600 rounded hover:bg-gray-500 disabled:opacity-50"
-              disabled={i === selectedSheets.length - 1 || busy}
+              disabled={i === combineSelection.length - 1 || busy}
               on:click={() => move(i, 1)}
             >
               ↓
@@ -71,10 +79,10 @@
     </div>
     <button
       class="mt-2 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-500 disabled:opacity-50"
-      disabled={selectedSheets.length < 2 || busy}
+      disabled={combineSelection.length < 2 || busy}
       on:click={() => showModal()}
     >
-      Combine {selectedSheets.length} Sheets...
+      Combine {combineSelection.length} Sheets...
     </button>
   </div>
 {/if}
@@ -147,7 +155,8 @@
       <button
         disabled={busy}
         class="w-full p-2 bg-gray-600 rounded hover:bg-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
-        on:click={() => dispatch("command", { type: "transposes" })}
+        on:click={() =>
+          dispatch("command", { type: "transposes", tempSettings })}
       >
         Copy Transposes
       </button>

--- a/src/components/HistoryCombineDialog.svelte
+++ b/src/components/HistoryCombineDialog.svelte
@@ -59,12 +59,19 @@
     <h3 class="text-xl text-white">
       Selected Sheets ({combineSelection.length})
     </h3>
-    <div class="flex flex-col gap-1 w-full relative">
+    <div
+      class="flex flex-col gap-1 w-full relative max-h-[200px] min-w-[200px] max-w-[400px] overflow-y-auto"
+    >
       {#each combineSelection as sheet, i (i)}
         <div
           class="flex items-center justify-between text-white p-2 bg-gray-700 rounded gap-2"
         >
-          <span>{sheet.name}</span>
+          <div class="flex items-center gap-2 overflow-hidden">
+            <span class="text-gray-400 text-xs tabular-nums">{i + 1}.</span>
+            <span class="truncate max-w-[400px]" title={sheet.name}>
+              {sheet.name}
+            </span>
+          </div>
           <div class="flex gap-1">
             <button
               class="px-2 py-0.5 bg-gray-600 rounded hover:bg-gray-500 disabled:opacity-50"

--- a/src/components/HistoryCombineDialog.svelte
+++ b/src/components/HistoryCombineDialog.svelte
@@ -36,6 +36,13 @@
     combineSelection = newItems;
   }
 
+  function remove(index) {
+    if (busy) return;
+    const newItems = [...combineSelection];
+    newItems.splice(index, 1);
+    combineSelection = newItems;
+  }
+
   export function showModal() {
     historyCombineDialog.showModal();
   }
@@ -53,7 +60,7 @@
       Selected Sheets ({combineSelection.length})
     </h3>
     <div class="flex flex-col gap-1 w-full relative">
-      {#each combineSelection as sheet, i (sheet.name)}
+      {#each combineSelection as sheet, i (i)}
         <div
           class="flex items-center justify-between text-white p-2 bg-gray-700 rounded gap-2"
         >
@@ -72,6 +79,13 @@
               on:click={() => move(i, 1)}
             >
               ↓
+            </button>
+            <button
+              class="px-2 py-0.5 bg-red-600 rounded hover:bg-red-500 disabled:opacity-50"
+              disabled={busy}
+              on:click={() => remove(i)}
+            >
+              ✕
             </button>
           </div>
         </div>

--- a/src/components/HistoryCombineDialog.svelte
+++ b/src/components/HistoryCombineDialog.svelte
@@ -1,0 +1,171 @@
+<script>
+  import { createEventDispatcher, onMount } from "svelte";
+  import SheetOptions from "./SheetOptions.svelte";
+
+  const dispatch = createEventDispatcher();
+
+  export let selectedSheets = [];
+  export let settings = {}; // Current app settings to initialize defaults
+
+  let historyCombineDialog;
+  let busy = false;
+  let tempSettings = {};
+
+  // Initialize tempSettings when settings prop changes or on mount
+  $: if (settings && Object.keys(tempSettings).length === 0) {
+    tempSettings = { ...settings };
+  }
+
+  function move(index, direction) {
+    if (busy) return;
+    const newItems = [...selectedSheets];
+    const targetIndex = index + direction;
+    if (targetIndex < 0 || targetIndex >= newItems.length) return;
+
+    const temp = newItems[index];
+    newItems[index] = newItems[targetIndex];
+    newItems[targetIndex] = temp;
+    selectedSheets = newItems;
+  }
+
+  export function showModal() {
+    historyCombineDialog.showModal();
+  }
+
+  export function close() {
+    if (!busy) historyCombineDialog.close();
+  }
+</script>
+
+{#if selectedSheets.length > 0}
+  <div
+    class="flex flex-col items-center gap-2 p-4 border border-gray-600 rounded-lg bg-gray-800"
+  >
+    <h3 class="text-xl text-white">
+      Selected Sheets ({selectedSheets.length})
+    </h3>
+    <div class="flex flex-col gap-1 w-full relative">
+      {#each selectedSheets as sheet, i (sheet.name)}
+        <div
+          class="flex items-center justify-between text-white p-2 bg-gray-700 rounded gap-2"
+        >
+          <span>{sheet.name}</span>
+          <div class="flex gap-1">
+            <button
+              class="px-2 py-0.5 bg-gray-600 rounded hover:bg-gray-500 disabled:opacity-50"
+              disabled={i === 0 || busy}
+              on:click={() => move(i, -1)}
+            >
+              ↑
+            </button>
+            <button
+              class="px-2 py-0.5 bg-gray-600 rounded hover:bg-gray-500 disabled:opacity-50"
+              disabled={i === selectedSheets.length - 1 || busy}
+              on:click={() => move(i, 1)}
+            >
+              ↓
+            </button>
+          </div>
+        </div>
+      {/each}
+    </div>
+    <button
+      class="mt-2 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-500 disabled:opacity-50"
+      disabled={selectedSheets.length < 2 || busy}
+      on:click={() => showModal()}
+    >
+      Combine {selectedSheets.length} Sheets...
+    </button>
+  </div>
+{/if}
+
+<!-- svelte-ignore a11y-no-noninteractive-element-interactions -->
+<dialog
+  bind:this={historyCombineDialog}
+  on:cancel|preventDefault={(e) => {
+    if (busy) e.preventDefault();
+    else historyCombineDialog.close();
+  }}
+  on:close|preventDefault={() => {}}
+  class="rounded-lg bg-gray-800 text-white p-6 border border-gray-600 outline-none max-h-[90vh] overflow-y-auto"
+>
+  <div class="flex flex-col gap-4 min-w-[350px]">
+    <h2 class="text-xl font-bold text-center mb-2">Combine Sheets</h2>
+
+    <details
+      class="bg-gray-700 rounded-lg overflow-hidden border border-gray-600"
+    >
+      <summary
+        class="p-3 cursor-pointer hover:bg-gray-600 font-semibold select-none"
+      >
+        Generation Settings
+      </summary>
+      <div class="p-3 bg-gray-800 text-sm">
+        <SheetOptions
+          bind:settings={tempSettings}
+          show={true}
+          hasMIDI={false}
+          hideTranspositionSettings={true}
+        />
+      </div>
+    </details>
+
+    <div class="flex flex-col gap-2">
+      <h3 class="font-semibold text-gray-300">Image</h3>
+      <div class="flex gap-2">
+        <button
+          disabled={busy}
+          class="flex-1 p-2 bg-blue-600 rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          on:click={() =>
+            dispatch("command", {
+              type: "image",
+              mode: "copy",
+              tempSettings,
+            })}
+        >
+          Copy Image
+        </button>
+        <button
+          disabled={busy}
+          class="flex-1 p-2 bg-blue-600 rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          on:click={() =>
+            dispatch("command", {
+              type: "image",
+              mode: "download",
+              tempSettings,
+            })}
+        >
+          Download Image
+        </button>
+      </div>
+    </div>
+
+    <hr class="border-gray-600" />
+
+    <div class="flex flex-col gap-2">
+      <h3 class="font-semibold text-gray-300">Text Data</h3>
+      <button
+        disabled={busy}
+        class="w-full p-2 bg-gray-600 rounded hover:bg-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        on:click={() => dispatch("command", { type: "transposes" })}
+      >
+        Copy Transposes
+      </button>
+      <button
+        disabled={busy}
+        class="w-full p-2 bg-gray-600 rounded hover:bg-gray-500 disabled:opacity-50 disabled:cursor-not-allowed"
+        on:click={() => dispatch("command", { type: "text", tempSettings })}
+      >
+        Copy Text
+      </button>
+    </div>
+
+    <button
+      disabled={busy}
+      class="mt-4 p-2 border border-gray-500 rounded hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+      on:click={() => close()}
+    >
+      {busy ? "Processing..." : "Cancel"}
+    </button>
+  </div>
+</dialog>

--- a/src/components/HistoryCombineDialog.svelte
+++ b/src/components/HistoryCombineDialog.svelte
@@ -1,15 +1,16 @@
 <script>
   import { createEventDispatcher, onMount } from "svelte";
   import SheetOptions from "./SheetOptions.svelte";
+  import { getDefaultSettings } from "../utils/Settings";
 
   const dispatch = createEventDispatcher();
 
   export let combineSelection = [];
-  export let appSettings = {};
+  export let appSettings = getDefaultSettings();
 
   let historyCombineDialog;
   let busy = false;
-  let tempSettings = {};
+  let tempSettings = getDefaultSettings();
   let progressPercent = 0;
   let progressDescription = "";
 

--- a/src/components/HistoryCombineDialog.svelte
+++ b/src/components/HistoryCombineDialog.svelte
@@ -10,6 +10,8 @@
   let historyCombineDialog;
   let busy = false;
   let tempSettings = {};
+  let progressPercent = 0;
+  let progressDescription = "";
 
   // Initialize tempSettings from appSettings if not yet set
   $: if (appSettings && Object.keys(tempSettings).length === 0) {
@@ -18,6 +20,15 @@
 
   export function setBusy(val) {
     busy = val;
+    if (!val) {
+      progressPercent = 0;
+      progressDescription = "";
+    }
+  }
+
+  export function setProgress(percent, description) {
+    progressPercent = Math.round(percent);
+    progressDescription = description || "";
   }
 
   export function resetSettings() {
@@ -142,18 +153,21 @@
     <div class="flex flex-col gap-2">
       <h3 class="font-semibold text-gray-300">Image</h3>
       <div class="flex gap-2">
-        <button
-          disabled={busy}
-          class="flex-1 p-2 bg-blue-600 rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-          on:click={() =>
-            dispatch("command", {
-              type: "image",
-              mode: "copy",
-              tempSettings,
-            })}
-        >
-          Copy Image
-        </button>
+        {#if typeof ClipboardItem !== "undefined"}
+          <!-- note: in case it is not supported by mozilla -->
+          <button
+            disabled={busy}
+            class="flex-1 p-2 bg-blue-600 rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            on:click={() =>
+              dispatch("command", {
+                type: "image",
+                mode: "copy",
+                tempSettings,
+              })}
+          >
+            Copy Image
+          </button>
+        {/if}
         <button
           disabled={busy}
           class="flex-1 p-2 bg-blue-600 rounded hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
@@ -189,6 +203,23 @@
         Copy Text
       </button>
     </div>
+
+    {#if busy}
+      <div class="flex flex-col gap-2 mt-2">
+        <div class="flex justify-between items-center text-sm">
+          <span class="text-gray-300"
+            >{progressDescription || "Starting..."}</span
+          >
+          <span class="text-gray-400 tabular-nums">{progressPercent}%</span>
+        </div>
+        <div class="w-full h-2 bg-gray-700 rounded-full overflow-hidden">
+          <div
+            class="h-full bg-blue-500 rounded-full"
+            style="width: {progressPercent}%"
+          ></div>
+        </div>
+      </div>
+    {/if}
 
     <button
       disabled={busy}

--- a/src/components/HistoryCombineDialog.svelte
+++ b/src/components/HistoryCombineDialog.svelte
@@ -66,17 +66,19 @@
 
 {#if combineSelection.length > 0}
   <div
-    class="flex flex-col items-center gap-2 p-4 border border-gray-600 rounded-lg bg-gray-800"
+    class="flex flex-col items-center gap-2 p-4 border rounded-lg"
+    style="border: 1px solid dimgrey"
   >
     <h3 class="text-xl text-white">
-      Selected Sheets ({combineSelection.length})
+      Selected sheets ({combineSelection.length})
     </h3>
     <div
       class="flex flex-col gap-1 w-full relative max-h-[200px] min-w-[200px] max-w-[400px] overflow-y-auto"
     >
       {#each combineSelection as sheet, i (i)}
         <div
-          class="flex items-center justify-between text-white p-2 bg-gray-700 rounded gap-2"
+          class="flex items-center justify-between text-white p-2 border rounded gap-2"
+          style="border: 1px solid dimgrey"
         >
           <div class="flex items-center gap-2 overflow-hidden">
             <span class="text-gray-400 text-xs tabular-nums">{i + 1}.</span>
@@ -111,11 +113,11 @@
       {/each}
     </div>
     <button
-      class="mt-2 px-4 py-2 bg-green-600 text-white rounded hover:bg-green-500 disabled:opacity-50"
+      class="mt-2 !px-4 !py-2 bg-green-600 text-white rounded hover:bg-green-500 disabled:opacity-50"
       disabled={combineSelection.length < 2 || busy}
       on:click={() => showModal()}
     >
-      Combine {combineSelection.length} Sheets...
+      Combine {combineSelection.length} sheets
     </button>
   </div>
 {/if}
@@ -128,20 +130,23 @@
     else historyCombineDialog.close();
   }}
   on:close|preventDefault={() => {}}
-  class="rounded-lg bg-gray-800 text-white p-6 border border-gray-600 outline-none max-h-[90vh] overflow-y-auto"
+  class="rounded-lg text-white p-6 border outline-none max-h-[90vh] overflow-y-auto"
+  style="background-color: #242424; border: 1px solid dimgrey"
 >
   <div class="flex flex-col gap-4 min-w-[350px]">
-    <h2 class="text-xl font-bold text-center mb-2">Combine Sheets</h2>
+    <h2 class="text-xl font-bold text-center mb-2">Combine sheets</h2>
 
     <details
-      class="bg-gray-700 rounded-lg overflow-hidden border border-gray-600"
+      class="rounded-lg overflow-hidden border"
+      style="background-color: #3a3a3a; border: 1px solid dimgrey"
     >
       <summary
-        class="p-3 cursor-pointer hover:bg-gray-600 font-semibold select-none"
+        class="p-3 cursor-pointer hover:bg-neutral-700 font-semibold select-none"
+        style="background-color: #2a2a2a"
       >
         Generation Settings
       </summary>
-      <div class="p-3 bg-gray-800 text-sm">
+      <div class="p-3 text-sm" style="background-color: #292929">
         <SheetOptions
           bind:settings={tempSettings}
           show={true}
@@ -184,7 +189,7 @@
       </div>
     </div>
 
-    <hr class="border-gray-600" />
+    <hr style="border: 1px solid dimgrey" />
 
     <div class="flex flex-col gap-2">
       <h3 class="font-semibold text-gray-300">Text Data</h3>

--- a/src/components/HistoryEntry.svelte
+++ b/src/components/HistoryEntry.svelte
@@ -35,7 +35,7 @@
 
   let processDecision = () => {
     if (removalDialog.returnValue == "export-and-delete") {
-      dispatch("export");
+      dispatch("export", { project: piece });
       history.delete(piece.name);
       dispatch("refresh");
     } else if (removalDialog.returnValue == "delete") {

--- a/src/components/HistoryEntry.svelte
+++ b/src/components/HistoryEntry.svelte
@@ -8,6 +8,8 @@
   import { onMount } from "svelte";
 
   export let piece;
+  export let sheetSelectable = false;
+  export let sheetSelected = false;
 
   let title; // HTMLElement
 
@@ -19,7 +21,12 @@
   // onMount(wrapOnUnderlines)
 
   let load = () => {
-    dispatch("load", { project: piece });
+    if (sheetSelectable) {
+      sheetSelected = !sheetSelected;
+      dispatch("select", { selected: sheetSelected, project: piece });
+    } else {
+      dispatch("load", { project: piece });
+    }
   };
 
   let removalDialog;
@@ -61,10 +68,19 @@
 <button
   title={piece.name}
   on:click={load}
-  class="max-w-64 text-dimgrey justify-center align-middle text-nowrap text-ellipsis overflow-hidden"
-  style="background: none !important; border: 1px solid dimgrey"
+  class="max-w-64 text-dimgrey justify-center align-middle text-nowrap text-ellipsis overflow-hidden relative"
+  style="background: none !important; border: 1px solid dimgrey; {sheetSelected ? 'border-color: lightgreen' : ''}"
   on:contextmenu|preventDefault={remove}
 >
+  {#if sheetSelectable}
+    <div class="absolute top-1 left-1">
+      <input
+        type="checkbox"
+        bind:checked={sheetSelected}
+        class="pointer-events-none"
+      />
+    </div>
+  {/if}
   <div
     bind:this={title}
     style="white-space: nowrap; text-overflow: ellipsis; overflow: hidden"

--- a/src/components/HistoryEntry.svelte
+++ b/src/components/HistoryEntry.svelte
@@ -69,14 +69,14 @@
   on:click={load}
   class="max-w-64 text-dimgrey justify-center align-middle text-nowrap text-ellipsis overflow-hidden relative"
   style="background: none !important; border: 1px solid dimgrey; {sheetSelected
-    ? 'border-color: lightgreen'
+    ? 'border-color: #ff966d'
     : ''}"
   on:contextmenu|preventDefault={remove}
 >
   {#if sheetSelectable && sheetSelected}
     <div class="absolute top-1 left-1">
       <!-- Checked indicator (visual only) -->
-      <div class="w-2 h-2 bg-green-500 rounded-full"></div>
+      <div class="w-2 h-2 rounded-full" style="background-color: #ff966d"></div>
     </div>
   {/if}
   <div

--- a/src/components/HistoryEntry.svelte
+++ b/src/components/HistoryEntry.svelte
@@ -22,8 +22,7 @@
 
   let load = () => {
     if (sheetSelectable) {
-      sheetSelected = !sheetSelected;
-      dispatch("select", { selected: sheetSelected, project: piece });
+      dispatch("select", { selected: true, project: piece });
     } else {
       dispatch("load", { project: piece });
     }
@@ -69,16 +68,15 @@
   title={piece.name}
   on:click={load}
   class="max-w-64 text-dimgrey justify-center align-middle text-nowrap text-ellipsis overflow-hidden relative"
-  style="background: none !important; border: 1px solid dimgrey; {sheetSelected ? 'border-color: lightgreen' : ''}"
+  style="background: none !important; border: 1px solid dimgrey; {sheetSelected
+    ? 'border-color: lightgreen'
+    : ''}"
   on:contextmenu|preventDefault={remove}
 >
-  {#if sheetSelectable}
+  {#if sheetSelectable && sheetSelected}
     <div class="absolute top-1 left-1">
-      <input
-        type="checkbox"
-        bind:checked={sheetSelected}
-        class="pointer-events-none"
-      />
+      <!-- Checked indicator (visual only) -->
+      <div class="w-2 h-2 bg-green-500 rounded-full"></div>
     </div>
   {/if}
   <div

--- a/src/components/HistoryList.svelte
+++ b/src/components/HistoryList.svelte
@@ -10,11 +10,7 @@
 
   function handleSelect(piece, selected) {
     if (selected) {
-      if (!selectedSheets.some((p) => p.name === piece.name)) {
-        selectedSheets = [...selectedSheets, piece];
-      }
-    } else {
-      selectedSheets = selectedSheets.filter((p) => p.name !== piece.name);
+      selectedSheets = [...selectedSheets, piece];
     }
     dispatch("selectChange", { selectedSheets });
   }

--- a/src/components/HistoryList.svelte
+++ b/src/components/HistoryList.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { createEventDispatcher } from "svelte";
+  import HistoryEntry from "./HistoryEntry.svelte";
+
+  const dispatch = createEventDispatcher();
+
+  export let pieces = [];
+  export let selectable = false;
+  export let selectedSheets = [];
+
+  function handleSelect(piece, selected) {
+    if (selected) {
+      if (!selectedSheets.some((p) => p.name === piece.name)) {
+        selectedSheets = [...selectedSheets, piece];
+      }
+    } else {
+      selectedSheets = selectedSheets.filter((p) => p.name !== piece.name);
+    }
+    dispatch("selectChange", { selectedSheets });
+  }
+</script>
+
+<div
+  class="w-3/4 flex flex-wrap justify-center gap-2 overflow-clip text-ellipsis"
+>
+  {#each pieces as piece (piece.name)}
+    <HistoryEntry
+      {piece}
+      sheetSelectable={selectable}
+      sheetSelected={selectedSheets.some((p) => p.name === piece.name)}
+      on:select={(e) => handleSelect(piece, e.detail.selected)}
+      on:load={(x) => {
+        if (!selectable) dispatch("load", x.detail);
+      }}
+      on:refresh
+      on:export
+    />
+  {/each}
+</div>

--- a/src/components/SheetActions.svelte
+++ b/src/components/SheetActions.svelte
@@ -9,6 +9,7 @@
 </script>
 
 <div class="flex flex-row gap-1 sticky top-0 z-10 app-background-color">
+  <button on:click={() => dispatch("addTitle")}>Add title</button>
   <button on:click={() => dispatch("copyText")}>Copy Text</button>
 
   <button
@@ -56,6 +57,11 @@
       <SelectionIcon />
     {/if}
   </button>
-  <button on:click={() => dispatch("addTitle")}>Add title</button>
+  <button disabled={!hasSelection} on:click={() => dispatch("splitSheet")}>
+    Split Sheet
+    {#if hasSelection}
+      <SelectionIcon />
+    {/if}
+  </button>
   <button on:click={() => dispatch("export")}>Export</button>
 </div>

--- a/src/components/SheetActions.svelte
+++ b/src/components/SheetActions.svelte
@@ -5,6 +5,7 @@
   export let settings;
 
   export let hasSelection = false;
+  export let isAllNotesSelected = false;
   let dispatch = createEventDispatcher();
 </script>
 
@@ -58,7 +59,11 @@
     {/if}
   </button>
   <button disabled={!hasSelection} on:click={() => dispatch("splitSheet")}>
-    Split Sheet
+    {#if isAllNotesSelected}
+      Duplicate Sheet
+    {:else}
+      Split Sheet
+    {/if}
     {#if hasSelection}
       <SelectionIcon />
     {/if}

--- a/src/components/SheetOptions.svelte
+++ b/src/components/SheetOptions.svelte
@@ -1,6 +1,7 @@
 <script>
   import { createEventDispatcher } from "svelte";
   import { vpScale } from "../utils/VP";
+  import { fonts, getDefaultSettings } from "../utils/Settings";
 
   let dispatch = createEventDispatcher();
 
@@ -8,17 +9,7 @@
   export let hasMIDI = false;
   export let hideTranspositionSettings = false;
 
-  let fonts = [
-    "Verdana",
-    "Tahoma",
-    "Dejavu Sans",
-    "Segoe UI",
-    "Helvetica",
-    "Lucida Console",
-    "Candara",
-  ];
-
-  export let settings = {};
+  export let settings = getDefaultSettings();
 </script>
 
 {#if show}

--- a/src/components/SheetOptions.svelte
+++ b/src/components/SheetOptions.svelte
@@ -18,31 +18,7 @@
     "Candara",
   ];
 
-  export let settings = {
-    beats: 4,
-    breaks: "realistic",
-    quantize: 35,
-    classicChordOrder: false,
-    sequentialQuantize: true,
-    curlyQuantizes: true,
-    pShifts: "Start",
-    pOors: "Inorder",
-    oors: true,
-    tempoMarks: false,
-    oorMarks: false,
-    bpmChanges: true,
-    bpmType: "detailed",
-    minSpeedChange: 10,
-    oorSeparator: ":",
-    resilience: 2,
-    stickyAutoTransposition: false,
-    font: fonts[0],
-    lineHeight: 135,
-    capturingImage: false,
-    missingTempo: false,
-    bpm: 120,
-    tracks: [{}], // populated from main, default = all selected
-  };
+  export let settings = {};
 </script>
 
 {#if show}

--- a/src/components/SheetOptions.svelte
+++ b/src/components/SheetOptions.svelte
@@ -26,7 +26,7 @@
     <hr class="my-2 mx-1" />
 
     {#each settings.tracks as track, idx}
-      <label for="trackbox{idx + 1}">
+      <label for="trackbox{idx + 1}" class="track-label">
         <input
           id="trackbox{idx + 1}"
           type="checkbox"
@@ -37,8 +37,11 @@
             settings.tracks = settings.tracks.map((track) => ({ ...track }));
           }}
         />
-        Track {idx + 1} - {track.name}
-        {track.instrument ? `(${track.instrument}) ` : ""}- {track.length} events
+        <span>
+          Track {idx + 1} - {track.name}
+          {track.instrument ? `(${track.instrument}) ` : ""}- {track.length}
+          events
+        </span>
       </label>
     {/each}
   {/if}
@@ -198,7 +201,7 @@
       </div>
     {/if}
 
-    <label for="classic-chord-order">
+    <label class="checkbox-label">
       <input
         type="checkbox"
         id="classic-chord-order"
@@ -207,7 +210,7 @@
       Classic chord order
     </label>
 
-    <label for="order-quantizes">
+    <label class="checkbox-label">
       <input
         type="checkbox"
         id="order-quantizes"
@@ -221,7 +224,7 @@
       </span>
     </label>
 
-    <label for="curly-quantizes">
+    <label class="checkbox-label">
       <input
         type="checkbox"
         id="curly-quantizes"
@@ -230,14 +233,14 @@
       Curly braces for quantized chords
     </label>
 
-    <label for="out-of-range">
+    <label class="checkbox-label">
       <input type="checkbox" id="out-of-range" bind:checked={settings.oors} />
       Include out of range (ctrl) notes
     </label>
 
     <hr class="my-2 mx-1" />
 
-    <label for="tempo-checkbox">
+    <label class="checkbox-label">
       <input
         type="checkbox"
         id="tempo-checkbox"
@@ -246,7 +249,7 @@
       Show tempo/timing marks
     </label>
 
-    <label for="oormark-checkbox">
+    <label class="checkbox-label">
       <input
         type="checkbox"
         id="oormark-checkbox"
@@ -301,7 +304,7 @@
     <hr class="my-2 mx-1" />
 
     {#if hasMIDI && !settings.missingTempo}
-      <label for="bpm-changes">
+      <label for="bpm-changes" class="checkbox-label">
         <input
           type="checkbox"
           id="bpm-changes"
@@ -375,6 +378,20 @@
     label {
       max-width: fit-content;
       text-align: center;
+      user-select: none;
+    }
+
+    label:hover {
+      color: lightgray;
+    }
+
+    .track-label,
+    .checkbox-label {
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.4em;
+      margin-bottom: 0.2em;
     }
 
     .select-div {

--- a/src/components/SheetOptions.svelte
+++ b/src/components/SheetOptions.svelte
@@ -6,6 +6,7 @@
 
   export let show;
   export let hasMIDI = false;
+  export let hideTranspositionSettings = false;
 
   let fonts = [
     "Verdana",
@@ -66,46 +67,48 @@
     {/each}
   {/if}
 
-  <hr class="my-2 mx-1" />
+  {#if !hideTranspositionSettings}
+    <hr class="my-2 mx-1" />
 
-  <div
-    class="flex flex-col items-start align-middle"
-    style="margin-top: -0.7em"
-  >
-    <div class="flex flex-row mt-3">
-      <label
-        class="flex flex-row items-center"
-        title="Defines how much better a transposition should be than the previous transposition for multi-transpose to act (higher = less transposing)"
-        for="atleast">Resilience (?):</label
-      >
-      <input
-        class="w-32"
-        id="atleast"
-        type="range"
-        min="0"
-        max="12"
-        bind:value={settings.resilience}
-      />
-      <span style="display:flex; align-items: center"
-        >{settings.resilience}</span
-      >
+    <div
+      class="flex flex-col items-start align-middle"
+      style="margin-top: -0.7em"
+    >
+      <div class="flex flex-row mt-3">
+        <label
+          class="flex flex-row items-center"
+          title="Defines how much better a transposition should be than the previous transposition for multi-transpose to act (higher = less transposing)"
+          for="atleast">Resilience (?):</label
+        >
+        <input
+          class="w-32"
+          id="atleast"
+          type="range"
+          min="0"
+          max="12"
+          bind:value={settings.resilience}
+        />
+        <span style="display:flex; align-items: center"
+          >{settings.resilience}</span
+        >
+      </div>
+      <div class="flex flex-row mt-3">
+        <label
+          class="flex flex-row items-center"
+          title="Defines whether or not the transposed region(s) should be related to previous regions"
+          for="sticky-auto-transposition">Sticky auto-transposition (?):</label
+        >
+        <input
+          class="mx-1"
+          type="checkbox"
+          id="sticky-auto-transposition"
+          bind:checked={settings.stickyAutoTransposition}
+        />
+      </div>
     </div>
-    <div class="flex flex-row mt-3">
-      <label
-        class="flex flex-row items-center"
-        title="Defines whether or not the transposed region(s) should be related to previous regions"
-        for="sticky-auto-transposition">Sticky auto-transposition (?):</label
-      >
-      <input
-        class="mx-1"
-        type="checkbox"
-        id="sticky-auto-transposition"
-        bind:checked={settings.stickyAutoTransposition}
-      />
-    </div>
-  </div>
 
-  <hr class="my-2 mx-1" />
+    <hr class="my-2 mx-1" />
+  {/if}
 
   <div>
     <!-- {#if hasMIDI} -->

--- a/src/utils/GlobalContext.js
+++ b/src/utils/GlobalContext.js
@@ -1,0 +1,12 @@
+let globalContext = null;
+
+export function setGlobalContext(ctx) {
+  globalContext = ctx;
+}
+
+export function getGlobalContext() {
+  if (!globalContext) {
+    throw new Error("Global context not initialized");
+  }
+  return globalContext;
+}

--- a/src/utils/History.js
+++ b/src/utils/History.js
@@ -43,7 +43,7 @@ const module = {
     return pieces;
   },
 
-  add: async (name, settings, json, skip_compression = false) => {
+  add: async (name, settings, json, skip_compression = false, opts = {}) => {
     let pieces = module.getAll();
 
     let thisPieceRemoved = pieces.filter((entry) => entry.name != name);
@@ -54,11 +54,17 @@ const module = {
     try {
       localStorage.setItem(_key, JSON.stringify(thisPieceRemoved));
       addToast("Saved!", "success");
-    } catch ({ error, message }) {
-      if (
-        error == "QuotaExceededError" ||
-        message == "The quota has been exceeded."
-      ) {
+    } catch (e) {
+      const errorMsg = e.message || "";
+      const isQuotaError =
+        e.name === "QuotaExceededError" ||
+        e.code === 22 ||
+        e.code === 1014 ||
+        errorMsg.includes("QuotaExceededError") ||
+        errorMsg.includes("The quota has been exceeded.") ||
+        errorMsg.includes("NS_ERROR_DOM_QUOTA_REACHED");
+
+      if (isQuotaError && !opts.noAutoDelete) {
         const dropped = thisPieceRemoved.pop();
         console.log("Quota exceeded, dropping: ", dropped);
         thisPieceRemoved.shift(); // undo addition
@@ -72,9 +78,11 @@ const module = {
 
         module.add(name, settings, json, skip_compression);
       } else {
-        console.error(error, message);
-        addToast("Failed to save due to storage limits!", "error");
-        throw new Error(message || "QuotaExceededError");
+        console.error(e);
+        if (!isQuotaError) {
+          addToast("Failed to save due to storage limits!", "error");
+        }
+        throw e;
       }
     }
   },

--- a/src/utils/HistoryCombine.js
+++ b/src/utils/HistoryCombine.js
@@ -399,7 +399,7 @@ export async function handleHistoryCombineCommand(e) {
     if (type === "image") {
       let downloadName = null;
       if (mode !== "copy") {
-        downloadName = prompt("Enter a filename:", ctx.getFilename());
+        downloadName = prompt("Enter a filename:", ctx.getFilename() || "");
         if (!downloadName || !downloadName.trim()) return; // User cancelled or left empty
       }
 

--- a/src/utils/HistoryCombine.js
+++ b/src/utils/HistoryCombine.js
@@ -2,6 +2,7 @@ import { getGlobalContext } from "./GlobalContext";
 import { domToBlob } from "modern-screenshot";
 import { decompress } from "./History";
 import { is_chord } from "../utils/VP";
+import { concatToBuffer } from "image-stitch/bundle";
 
 /**
  * Re-indexes transpose comments globally across one or more combined sheets and calculates relative differences.
@@ -10,7 +11,7 @@ export function reindexTransposes(data, globalIndex, lastTransposeValue) {
   let currentIndex = globalIndex;
   let currentLastValue = lastTransposeValue;
 
-  // Clone data to avoid mutating original source if cached (though decompress usually returns fresh)
+  // Clone data to avoid mutating original source
   let workingData = [...data];
 
   // Check if we need to inject an initial transpose comment
@@ -33,11 +34,7 @@ export function reindexTransposes(data, globalIndex, lastTransposeValue) {
           notop: true
         };
 
-        // Insert before the chord, or after title if close
-        // Simple heuristic: Insert at firstChordIndex is safe, or checking for Title
-        // Let's refine: Insert after last 'title' before firstChord?
-        // Actually, App.svelte just splices it in. 
-        // We will insert it immediately before the first chord to be safe.
+        // Insert before the first chord
         workingData.splice(firstChordIndex, 0, newComment);
       }
     }
@@ -45,24 +42,18 @@ export function reindexTransposes(data, globalIndex, lastTransposeValue) {
 
   const processedData = [];
 
-  // console.log("Reindexing transposes...", { globalIndex, lastTransposeValue, dataLength: workingData.length });
-
   for (const item of workingData) {
     if (item.kind === "transpose") {
-      // console.log("Found transpose item:", item.text);
       const match = item.text.match(/Transpose by:?\s*([+-]?\d+)/);
       if (match) {
         const val = parseInt(match[1]);
 
-        // Redundancy check: If the transpose value hasn't changed from the last known state,
-        // and we HAVE a last known state (i.e. not the very first sheet), skip it.
         if (currentLastValue !== undefined && val === currentLastValue) {
           continue;
         }
 
         let label = `Transpose by: ${val > 0 ? "+" : ""}${val}`;
 
-        // Add relative diff if we have a previous context
         if (currentLastValue !== undefined) {
           const diff = val - currentLastValue;
           label += ` (${diff > 0 ? "+" : ""}${diff})`;
@@ -75,8 +66,6 @@ export function reindexTransposes(data, globalIndex, lastTransposeValue) {
           text: `${label} #${currentIndex++}`,
         });
       } else {
-        // Fallback: Just re-index, ensuring space
-        // Try to strip existing index if present to avoid doubling
         let cleanText = item.text.replace(/ #\d+$/, "").trim();
         processedData.push({
           ...item,
@@ -139,18 +128,22 @@ function mergeConsecutiveBreaks(data) {
   return result;
 }
 
-
-
 /**
- * Iterates through sheets, loads them into the DOM via callback, and captures snapshots.
+ * Iterates through sheets, loads them into the DOM, and captures snapshots of the sheet in chunks.
+ * Uses image-stitch to combine PNGs directly, avoiding browser canvas size limits.
  */
 export async function generateCombinedImage({ selectedSheets, loadSheet, onProgress }) {
   let captures = [];
   let globalTransposeIndex = 1;
   let lastTransposeValue = undefined;
 
+  // Chunking and taking several images is safer and faster than taking a picture of a combined dom
+  const CHUNK_MAX_ITEMS = 6400; // magic/cool number that I found works well :shrug:
+  if (onProgress) onProgress(0, "Preparing sheets...");
+
+  // Phase 1: Prepare all sheets and prepare each sheet as chunks
+  const preparedSheets = [];
   for (let i = 0; i < selectedSheets.length; i++) {
-    if (onProgress) onProgress(i + 1, selectedSheets.length);
     const sheet = selectedSheets[i];
     let data = decompress(sheet.data);
 
@@ -172,65 +165,114 @@ export async function generateCombinedImage({ selectedSheets, loadSheet, onProgr
     // Strip leading/trailing breaks and merge consecutive ones
     const strippedData = mergeConsecutiveBreaks(reindexedData);
 
-    // Trigger UI load in parent
-    const target = await loadSheet(sheet.name, strippedData);
+    // Split the data into chunks before DOM loads
+    const chunks = [];
+    let currentChunk = [];
+    for (const item of strippedData) {
+      currentChunk.push(item);
+      if (item.type === "break" && currentChunk.length >= CHUNK_MAX_ITEMS) {
+        chunks.push(currentChunk);
+        currentChunk = [];
+      }
+    }
+    if (currentChunk.length > 0) chunks.push(currentChunk);
 
-    // Apply temporary generation settings (ordering, quantization) via softRegen
-    const ctx = getGlobalContext();
-    ctx.setForcedNextSheetStartTime(nextStart);
-    ctx.softRegen();
-
-    // Wait for Svelte to finish updating the DOM with the generation settings
-    await ctx.tick();
-
-    // Precise capture logic
-    target.style.height = "max-content";
-    target.style.width = "max-content";
-    target.style.whiteSpace = "nowrap";
-    void target.offsetHeight;
-
-    const rect = target.getBoundingClientRect();
-    const w = rect.width;
-    const padding = i === selectedSheets.length - 1 ? 15 : 0; // add some padding bottom of the final image
-    const h = rect.height + padding;
-
-    let options = {
-      scale: 2,
-      width: w,
-      height: h,
-      style: { backgroundColor: "#2D2A32" },
-    };
-
-    const blob = await domToBlob(target, options);
-    const bitmap = await createImageBitmap(blob);
-    captures.push(bitmap);
+    preparedSheets.push({ name: sheet.name, chunks, nextStart });
   }
 
-  // Final stitching
+  // Phase 2: Capture all chunks, tracking progress by total chunk count
+  const totalChunks = preparedSheets.reduce((sum, s) => sum + s.chunks.length, 0);
+  let completedChunks = 0;
+
+  for (let i = 0; i < preparedSheets.length; i++) {
+    const prep = preparedSheets[i];
+    const chunks = prep.chunks;
+
+    for (let c = 0; c < chunks.length; c++) {
+      const chunkData = chunks[c];
+
+      const target = await loadSheet(prep.name, chunkData);
+      const ctx = getGlobalContext();
+
+      if (c === chunks.length - 1) {
+        ctx.setForcedNextSheetStartTime(prep.nextStart);
+      } else {
+        ctx.setForcedNextSheetStartTime(undefined);
+      }
+
+      ctx.softRegen();
+      await ctx.tick();
+      await new Promise(r => setTimeout(r, 100));
+
+      target.style.height = "max-content";
+      target.style.width = "max-content";
+      target.style.whiteSpace = "nowrap";
+      void target.offsetHeight;
+
+      const rect = target.getBoundingClientRect();
+
+      const isLastOfAll = (i === preparedSheets.length - 1 && c === chunks.length - 1);
+      const padding = isLastOfAll ? 10 : 0;
+      const chunkH = rect.height + padding;
+
+      const options = {
+        scale: 2,
+        width: rect.width,
+        height: chunkH,
+        backgroundColor: "#2D2A32",
+        style: {
+          backgroundColor: "#2D2A32",
+          width: rect.width + "px"
+        },
+      };
+
+      try {
+        const blob = await domToBlob(target, options);
+        if (!blob) throw new Error("Captured chunk blob is null");
+        const buffer = await blob.arrayBuffer();
+        captures.push(new Uint8Array(buffer));
+      } catch (err) {
+        console.error(`Chunk capture failed at sheet ${i}, chunk ${c}:`, err);
+        throw err;
+      }
+
+      completedChunks++;
+      if (onProgress) {
+        const percent = (completedChunks / totalChunks) * 70; // Reserve last 30% for stitching
+        const chunkDetail = chunks.length > 1 ? ` (chunks ${c + 1}/${chunks.length})` : "";
+        onProgress(percent, `Capturing sheet ${i + 1} of ${selectedSheets.length}${chunkDetail}`);
+      }
+    }
+  }
+
+  // Final Stitching
   if (captures.length === 0) return null;
 
-  let totalWidth = 0;
-  let totalHeight = 0;
-  for (let img of captures) {
-    totalWidth = Math.max(totalWidth, img.width);
-    totalHeight += img.height;
+  try {
+    // image-stitch helps avoid canvas size limit, important for large combined sheets
+    const resultBuffer = await concatToBuffer({
+      inputs: captures,
+      layout: { columns: 1 },
+      outputFormat: 'png',
+      backgroundColor: '#2D2A32',
+      onProgress: (completed, total) => {
+        if (onProgress) {
+          const stitchPercent = 70 + (completed / total) * 30;
+          onProgress(stitchPercent, "Stitching images together...");
+        }
+      },
+    });
+
+    if (onProgress) onProgress(100, "Done!");
+
+    captures.length = 0;
+    preparedSheets.length = 0;
+
+    return new Blob([resultBuffer], { type: "image/png" });
+  } catch (err) {
+    console.error("Stitching failed:", err);
+    throw new Error(`Failed to stitch images: ${err.message}`);
   }
-
-  let canvas = document.createElement("canvas");
-  canvas.width = totalWidth;
-  canvas.height = totalHeight;
-  let ctx = canvas.getContext("2d");
-
-  ctx.fillStyle = "#2D2A32";
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-
-  let currentY = 0;
-  for (let img of captures) {
-    ctx.drawImage(img, 0, currentY);
-    currentY += img.height;
-  }
-
-  return new Promise((resolve) => canvas.toBlob(resolve));
 }
 
 /**
@@ -355,6 +397,12 @@ export async function handleHistoryCombineCommand(e) {
     }
 
     if (type === "image") {
+      let downloadName = null;
+      if (mode !== "copy") {
+        downloadName = prompt("Enter a filename:", ctx.getFilename());
+        if (!downloadName || !downloadName.trim()) return; // User cancelled or left empty
+      }
+
       ctx.addToast("Generating combined image...", "info");
       ctx.importer.hide();
       ctx.setIsHistoryMultiSelect(false);
@@ -366,17 +414,18 @@ export async function handleHistoryCombineCommand(e) {
         settings: ctx.getSettings(),
         loadSheet: (name, data) =>
           loadSheetForHistoryCombine(name, data),
-        onProgress: (current, total) => {
-          ctx.addToast(`Generating combined image (${current} / ${total})...`, "info");
+        onProgress: (percent, description) => {
+          ctx.HistoryCombineDialogComp.setProgress(percent, description);
         }
       });
 
       if (blob) {
-        if (mode === "copy") ctx.copyCapturedImage(blob);
-        else {
-          const name = prompt("Enter a filename:", ctx.getFilename());
-          if (name === null) return; // User cancelled
-          ctx.downloadCapturedImage(blob, name);
+        if (mode === "copy") {
+          // Note: copyCapturedImage in App.svelte already contains a safety size check (10MB)
+          // to prevent browser crashes (RESULT_CODE_KILLED_BAD_MESSAGE)
+          ctx.copyCapturedImage(blob);
+        } else {
+          ctx.downloadCapturedImage(blob, downloadName);
         }
       }
     } else if (type === "text") {
@@ -393,7 +442,8 @@ export async function handleHistoryCombineCommand(e) {
         loadSheet: (name, data, waitTime) =>
           loadSheetForHistoryCombine(name, data, waitTime),
         onProgress: (current, total) => {
-          ctx.addToast(`Generating combined text (${current} / ${total})...`, "info");
+          const percent = Math.round((current / total) * 100);
+          ctx.HistoryCombineDialogComp.setProgress(percent, `Processing sheet ${current} of ${total}...`);
         }
       });
 

--- a/src/utils/HistoryCombine.js
+++ b/src/utils/HistoryCombine.js
@@ -96,6 +96,52 @@ export function reindexTransposes(data, globalIndex, lastTransposeValue) {
 }
 
 /**
+ * Finds the playtime of the first available note in the sheet data.
+ */
+function getFirstNotePlayTime(data) {
+  const firstChord = data.find(is_chord);
+  return firstChord?.notes?.[0]?.playTime;
+}
+
+/**
+ * Removes leading and trailing breaks from the sheet data to eliminate extra vertical space.
+ * Also strips breaks that are redundant because they sit next to a transpose comment at the start/end.
+ */
+function stripLeadingAndTrailingBreaks(data) {
+  let result = [...data];
+
+  // Strip leading breaks
+  while (result.length > 0 && result[0].type === "break") {
+    result.shift();
+  }
+
+  // Strip trailing breaks
+  while (result.length > 0 && result[result.length - 1].type === "break") {
+    result.pop();
+  }
+
+  return result;
+}
+
+/**
+ * Merges consecutive breaks in the data to avoid double spacing.
+ */
+function mergeConsecutiveBreaks(data) {
+  const stripped = stripLeadingAndTrailingBreaks(data);
+  const result = [];
+  for (let i = 0; i < stripped.length; i++) {
+    const item = stripped[i];
+    if (item.type === "break" && result[result.length - 1]?.type === "break") {
+      continue; // Skip consecutive breaks
+    }
+    result.push(item);
+  }
+  return result;
+}
+
+
+
+/**
  * Iterates through sheets, loads them into the DOM via callback, and captures snapshots.
  */
 export async function generateCombinedImage({ selectedSheets, loadSheet }) {
@@ -103,27 +149,49 @@ export async function generateCombinedImage({ selectedSheets, loadSheet }) {
   let globalTransposeIndex = 1;
   let lastTransposeValue = undefined;
 
-  for (let sheet of selectedSheets) {
-    const rawData = decompress(sheet.data);
-    const { data, nextIndex, nextLastValue } = reindexTransposes(
-      rawData,
+  for (let i = 0; i < selectedSheets.length; i++) {
+    const sheet = selectedSheets[i];
+    let data = decompress(sheet.data);
+
+    // Look ahead to the next sheet for timing continuity
+    let nextStart = undefined;
+    if (i < selectedSheets.length - 1) {
+      const nextData = decompress(selectedSheets[i + 1].data);
+      nextStart = getFirstNotePlayTime(nextData);
+    }
+
+    const { data: reindexedData, nextIndex, nextLastValue } = reindexTransposes(
+      data,
       globalTransposeIndex,
       lastTransposeValue,
     );
     globalTransposeIndex = nextIndex;
     lastTransposeValue = nextLastValue;
 
+    // Strip leading/trailing breaks and merge consecutive ones
+    const strippedData = mergeConsecutiveBreaks(reindexedData);
+
     // Trigger UI load in parent
-    const target = await loadSheet(sheet.name, data);
+    const target = await loadSheet(sheet.name, strippedData);
+
+    // Apply temporary generation settings (ordering, quantization) via softRegen
+    const ctx = getGlobalContext();
+    ctx.setForcedNextSheetStartTime(nextStart);
+    ctx.softRegen();
+
+    // Wait for Svelte to finish updating the DOM with the generation settings
+    await ctx.tick();
 
     // Precise capture logic
     target.style.height = "max-content";
     target.style.width = "max-content";
+    target.style.whiteSpace = "nowrap";
     void target.offsetHeight;
 
     const rect = target.getBoundingClientRect();
     const w = rect.width;
-    const h = rect.height + 20; // + a bit of space to prevent overlapping between two images
+    const padding = i === selectedSheets.length - 1 ? 15 : 0; // add some padding bottom of the final image
+    const h = rect.height + padding;
 
     let options = {
       scale: 2,
@@ -172,17 +240,37 @@ export async function generateCombinedText({ selectedSheets, loadSheet }) {
   let globalTransposeIndex = 1;
   let lastTransposeValue = undefined;
 
-  for (let sheet of selectedSheets) {
-    const rawData = decompress(sheet.data);
-    const { data, nextIndex, nextLastValue } = reindexTransposes(
-      rawData,
+  for (let i = 0; i < selectedSheets.length; i++) {
+    const sheet = selectedSheets[i];
+    let data = decompress(sheet.data);
+
+    // Look ahead to the next sheet for timing continuity
+    let nextStart = undefined;
+    if (i < selectedSheets.length - 1) {
+      const nextData = decompress(selectedSheets[i + 1].data);
+      nextStart = getFirstNotePlayTime(nextData);
+    }
+
+    const { data: reindexedData, nextIndex, nextLastValue } = reindexTransposes(
+      data,
       globalTransposeIndex,
       lastTransposeValue,
     );
     globalTransposeIndex = nextIndex;
     lastTransposeValue = nextLastValue;
 
-    const target = await loadSheet(sheet.name, data, 400);
+    // Strip leading/trailing breaks and merge consecutive ones
+    const strippedData = mergeConsecutiveBreaks(reindexedData);
+
+    const target = await loadSheet(sheet.name, strippedData, 400);
+
+    // Apply temporary generation settings (ordering, quantization) via softRegen
+    const ctx = getGlobalContext();
+    ctx.setForcedNextSheetStartTime(nextStart);
+    ctx.softRegen();
+
+    await ctx.tick();
+
     let text = target.innerText;
 
     // Clean up redundant indices
@@ -245,6 +333,7 @@ export async function handleHistoryCombineCommand(e) {
     }
 
     if (type === "image") {
+      ctx.addToast("Generating combined image...", "info");
       ctx.importer.hide();
       ctx.setIsHistoryMultiSelect(false);
       ctx.setSheetReady(true);
@@ -266,6 +355,7 @@ export async function handleHistoryCombineCommand(e) {
         }
       }
     } else if (type === "text") {
+      ctx.addToast("Generating combined text...", "info");
       ctx.importer.hide();
       ctx.setIsHistoryMultiSelect(false);
       ctx.setSheetReady(true);
@@ -282,20 +372,26 @@ export async function handleHistoryCombineCommand(e) {
       navigator.clipboard.writeText(text);
       ctx.updateSettings({ oorMarks: currSettings.oorMarks, tempoMarks: currSettings.tempoMarks })
 
-      alert("Combined text copied to clipboard!");
+      ctx.addToast("Combined text copied to clipboard!", "success");
     } else if (type === "transposes") {
+      ctx.addToast("Copying transposes...", "info");
       const text = generateCombinedTransposes(ctx.getSelectedSheets());
-      navigator.clipboard.writeText(text);
-      alert("Transposes copied to clipboard!");
+      if (text) {
+        navigator.clipboard.writeText(text);
+        ctx.addToast("Transposes copied to clipboard!", "success");
+      } else {
+        ctx.addToast("No transposes found in selected sheets", "warning");
+      }
     }
   } catch (err) {
     console.error("Combining failed", err);
-    alert("Combining failed: " + err.message);
+    ctx.addToast("Combining failed: " + err.message, "warning");
   } finally {
     ctx.setChordsAndOtherwise(originalData);
     ctx.setFilename(originalFilename);
     ctx.setSheetReady(originalSheetReady);
     ctx.updateSettings(originalSettings);
+    ctx.setForcedNextSheetStartTime(undefined);
 
     if (!originalSheetReady) ctx.importer.show();
     ctx.setIsHistoryMultiSelect(true);

--- a/src/utils/HistoryCombine.js
+++ b/src/utils/HistoryCombine.js
@@ -286,9 +286,27 @@ export async function generateCombinedText({ selectedSheets, loadSheet }) {
  */
 export function generateCombinedTransposes(selectedSheets) {
   let allTransposes = [];
-  selectedSheets.forEach((sheet) => {
+  let globalTransposeIndex = 1;
+  let lastTransposeValue = undefined;
+
+  for (let i = 0; i < selectedSheets.length; i++) {
+    const sheet = selectedSheets[i];
     let data = decompress(sheet.data);
-    let transposes = data.filter((e) => e.kind === "transpose");
+
+    // Reuse reindexTransposes to handle:
+    // 1. Injecting missing transpose comments (e.g. for split sheets)
+    // 2. Filtering out consecutive duplicate values
+    const { data: reindexedData, nextIndex, nextLastValue } = reindexTransposes(
+      data,
+      globalTransposeIndex,
+      lastTransposeValue,
+    );
+
+    globalTransposeIndex = nextIndex;
+    lastTransposeValue = nextLastValue;
+
+    const transposes = reindexedData.filter((item) => item.kind === "transpose");
+
     let transposesText = transposes
       .map((e) => {
         const match = e.text.match(/Transpose by:\s(\+?(-?\d+))/);
@@ -296,8 +314,10 @@ export function generateCombinedTransposes(selectedSheets) {
       })
       .filter((x) => x)
       .join(" ");
+
     if (transposesText) allTransposes.push(transposesText);
-  });
+  }
+
   return allTransposes.join(" ");
 }
 

--- a/src/utils/HistoryCombine.js
+++ b/src/utils/HistoryCombine.js
@@ -144,12 +144,13 @@ function mergeConsecutiveBreaks(data) {
 /**
  * Iterates through sheets, loads them into the DOM via callback, and captures snapshots.
  */
-export async function generateCombinedImage({ selectedSheets, loadSheet }) {
+export async function generateCombinedImage({ selectedSheets, loadSheet, onProgress }) {
   let captures = [];
   let globalTransposeIndex = 1;
   let lastTransposeValue = undefined;
 
   for (let i = 0; i < selectedSheets.length; i++) {
+    if (onProgress) onProgress(i + 1, selectedSheets.length);
     const sheet = selectedSheets[i];
     let data = decompress(sheet.data);
 
@@ -235,12 +236,13 @@ export async function generateCombinedImage({ selectedSheets, loadSheet }) {
 /**
  * Generates combined text content from multiple sheets.
  */
-export async function generateCombinedText({ selectedSheets, loadSheet }) {
+export async function generateCombinedText({ selectedSheets, loadSheet, onProgress }) {
   let combinedText = "";
   let globalTransposeIndex = 1;
   let lastTransposeValue = undefined;
 
   for (let i = 0; i < selectedSheets.length; i++) {
+    if (onProgress) onProgress(i + 1, selectedSheets.length);
     const sheet = selectedSheets[i];
     let data = decompress(sheet.data);
 
@@ -364,6 +366,9 @@ export async function handleHistoryCombineCommand(e) {
         settings: ctx.getSettings(),
         loadSheet: (name, data) =>
           loadSheetForHistoryCombine(name, data),
+        onProgress: (current, total) => {
+          ctx.addToast(`Generating combined image (${current} / ${total})...`, "info");
+        }
       });
 
       if (blob) {
@@ -387,6 +392,9 @@ export async function handleHistoryCombineCommand(e) {
         selectedSheets: ctx.getSelectedSheets(),
         loadSheet: (name, data, waitTime) =>
           loadSheetForHistoryCombine(name, data, waitTime),
+        onProgress: (current, total) => {
+          ctx.addToast(`Generating combined text (${current} / ${total})...`, "info");
+        }
       });
 
       navigator.clipboard.writeText(text);

--- a/src/utils/HistoryCombine.js
+++ b/src/utils/HistoryCombine.js
@@ -1,0 +1,304 @@
+import { getGlobalContext } from "./GlobalContext";
+import { domToBlob } from "modern-screenshot";
+import { decompress } from "./History";
+import { is_chord } from "../utils/VP";
+
+/**
+ * Re-indexes transpose comments globally across one or more combined sheets and calculates relative differences.
+ */
+export function reindexTransposes(data, globalIndex, lastTransposeValue) {
+  let currentIndex = globalIndex;
+  let currentLastValue = lastTransposeValue;
+
+  // Clone data to avoid mutating original source if cached (though decompress usually returns fresh)
+  let workingData = [...data];
+
+  // Check if we need to inject an initial transpose comment
+  const hasTranspose = workingData.some(item => item.kind === "transpose");
+
+  if (!hasTranspose) {
+    let firstChordIndex = workingData.findIndex(item => is_chord(item));
+    if (firstChordIndex !== -1) {
+      const chord = workingData[firstChordIndex];
+      if (chord.notes && chord.notes.length > 0) {
+        const firstNote = chord.notes[0];
+        const transposition = firstNote.value - (firstNote.original ?? firstNote.value);
+
+        // App.svelte logic: text = `Transpose by: ${-transposition} #1`
+        // We create the base text, reindexing loop will add the #index
+        const newComment = {
+          type: "comment",
+          kind: "transpose",
+          text: `Transpose by: ${-transposition}`,
+          notop: true
+        };
+
+        // Insert before the chord, or after title if close
+        // Simple heuristic: Insert at firstChordIndex is safe, or checking for Title
+        // Let's refine: Insert after last 'title' before firstChord?
+        // Actually, App.svelte just splices it in. 
+        // We will insert it immediately before the first chord to be safe.
+        workingData.splice(firstChordIndex, 0, newComment);
+      }
+    }
+  }
+
+  const processedData = [];
+
+  // console.log("Reindexing transposes...", { globalIndex, lastTransposeValue, dataLength: workingData.length });
+
+  for (const item of workingData) {
+    if (item.kind === "transpose") {
+      // console.log("Found transpose item:", item.text);
+      const match = item.text.match(/Transpose by:?\s*([+-]?\d+)/);
+      if (match) {
+        const val = parseInt(match[1]);
+
+        // Redundancy check: If the transpose value hasn't changed from the last known state,
+        // and we HAVE a last known state (i.e. not the very first sheet), skip it.
+        if (currentLastValue !== undefined && val === currentLastValue) {
+          continue;
+        }
+
+        let label = `Transpose by: ${val > 0 ? "+" : ""}${val}`;
+
+        // Add relative diff if we have a previous context
+        if (currentLastValue !== undefined) {
+          const diff = val - currentLastValue;
+          label += ` (${diff > 0 ? "+" : ""}${diff})`;
+        }
+
+        currentLastValue = val;
+
+        processedData.push({
+          ...item,
+          text: `${label} #${currentIndex++}`,
+        });
+      } else {
+        // Fallback: Just re-index, ensuring space
+        // Try to strip existing index if present to avoid doubling
+        let cleanText = item.text.replace(/ #\d+$/, "").trim();
+        processedData.push({
+          ...item,
+          text: `${cleanText} #${currentIndex++}`,
+        });
+      }
+    } else {
+      processedData.push(item);
+    }
+  }
+
+  return {
+    data: processedData,
+    nextIndex: currentIndex,
+    nextLastValue: currentLastValue,
+  };
+}
+
+/**
+ * Iterates through sheets, loads them into the DOM via callback, and captures snapshots.
+ */
+export async function generateCombinedImage({ selectedSheets, loadSheet }) {
+  let captures = [];
+  let globalTransposeIndex = 1;
+  let lastTransposeValue = undefined;
+
+  for (let sheet of selectedSheets) {
+    const rawData = decompress(sheet.data);
+    const { data, nextIndex, nextLastValue } = reindexTransposes(
+      rawData,
+      globalTransposeIndex,
+      lastTransposeValue,
+    );
+    globalTransposeIndex = nextIndex;
+    lastTransposeValue = nextLastValue;
+
+    // Trigger UI load in parent
+    const target = await loadSheet(sheet.name, data);
+
+    // Precise capture logic
+    target.style.height = "max-content";
+    target.style.width = "max-content";
+    void target.offsetHeight;
+
+    const rect = target.getBoundingClientRect();
+    const w = rect.width;
+    const h = rect.height + 20; // + a bit of space to prevent overlapping between two images
+
+    let options = {
+      scale: 2,
+      width: w,
+      height: h,
+      style: { backgroundColor: "#2D2A32" },
+    };
+
+    const blob = await domToBlob(target, options);
+    const bitmap = await createImageBitmap(blob);
+    captures.push(bitmap);
+  }
+
+  // Final stitching
+  if (captures.length === 0) return null;
+
+  let totalWidth = 0;
+  let totalHeight = 0;
+  for (let img of captures) {
+    totalWidth = Math.max(totalWidth, img.width);
+    totalHeight += img.height;
+  }
+
+  let canvas = document.createElement("canvas");
+  canvas.width = totalWidth;
+  canvas.height = totalHeight;
+  let ctx = canvas.getContext("2d");
+
+  ctx.fillStyle = "#2D2A32";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  let currentY = 0;
+  for (let img of captures) {
+    ctx.drawImage(img, 0, currentY);
+    currentY += img.height;
+  }
+
+  return new Promise((resolve) => canvas.toBlob(resolve));
+}
+
+/**
+ * Generates combined text content from multiple sheets.
+ */
+export async function generateCombinedText({ selectedSheets, loadSheet }) {
+  let combinedText = "";
+  let globalTransposeIndex = 1;
+  let lastTransposeValue = undefined;
+
+  for (let sheet of selectedSheets) {
+    const rawData = decompress(sheet.data);
+    const { data, nextIndex, nextLastValue } = reindexTransposes(
+      rawData,
+      globalTransposeIndex,
+      lastTransposeValue,
+    );
+    globalTransposeIndex = nextIndex;
+    lastTransposeValue = nextLastValue;
+
+    const target = await loadSheet(sheet.name, data, 400);
+    let text = target.innerText;
+
+    // Clean up redundant indices
+    text = text.replace(/(Transpose by: [^#]*)(#\d+)/g, "$1");
+    combinedText += `${text}\n`;
+  }
+
+  return combinedText.trim();
+}
+
+/**
+ * Combines transpose values into a space-separated string.
+ */
+export function generateCombinedTransposes(selectedSheets) {
+  let allTransposes = [];
+  selectedSheets.forEach((sheet) => {
+    let data = decompress(sheet.data);
+    let transposes = data.filter((e) => e.kind === "transpose");
+    let transposesText = transposes
+      .map((e) => {
+        const match = e.text.match(/Transpose by:\s(\+?(-?\d+))/);
+        return match ? match[2] : null;
+      })
+      .filter((x) => x)
+      .join(" ");
+    if (transposesText) allTransposes.push(transposesText);
+  });
+  return allTransposes.join(" ");
+}
+
+/**
+ * Helper for the HistoryCombine utility to load a sheet and wait for layout.
+ */
+export async function loadSheetForHistoryCombine(
+  name,
+  data,
+  waitTime = 1200,
+) {
+  const ctx = getGlobalContext();
+  ctx.setChordsAndOtherwise(data);
+  ctx.setFilename(name);
+  await new Promise((r) => setTimeout(r, waitTime));
+  return ctx.getContainer().querySelector("div");
+}
+
+export async function handleHistoryCombineCommand(e) {
+  const ctx = getGlobalContext();
+  const { type, mode, tempSettings } = e.detail;
+
+  let originalData = ctx.getChordsAndOtherwise();
+  let originalFilename = ctx.getFilename();
+  let originalSheetReady = ctx.getSheetReady();
+  let originalSettings = { ...ctx.getSettings() };
+
+  try {
+    ctx.HistoryCombineDialogComp.setBusy(true);
+
+    if (tempSettings) {
+      ctx.updateSettings(tempSettings);
+    }
+
+    if (type === "image") {
+      ctx.importer.hide();
+      ctx.setIsHistoryMultiSelect(false);
+      ctx.setSheetReady(true);
+      ctx.updateSettings({ capturingImage: true, oorMarks: false });
+
+      const blob = await generateCombinedImage({
+        selectedSheets: ctx.getSelectedSheets(),
+        settings: ctx.getSettings(),
+        loadSheet: (name, data) =>
+          loadSheetForHistoryCombine(name, data),
+      });
+
+      if (blob) {
+        if (mode === "copy") ctx.copyCapturedImage(blob);
+        else {
+          const name = prompt("Enter a filename:", ctx.getFilename());
+          if (name === null) return; // User cancelled
+          ctx.downloadCapturedImage(blob, name);
+        }
+      }
+    } else if (type === "text") {
+      ctx.importer.hide();
+      ctx.setIsHistoryMultiSelect(false);
+      ctx.setSheetReady(true);
+
+      const currSettings = ctx.getSettings()
+      ctx.updateSettings({ oorMarks: true, tempoMarks: true });
+
+      const text = await generateCombinedText({
+        selectedSheets: ctx.getSelectedSheets(),
+        loadSheet: (name, data, waitTime) =>
+          loadSheetForHistoryCombine(name, data, waitTime),
+      });
+
+      navigator.clipboard.writeText(text);
+      ctx.updateSettings({ oorMarks: currSettings.oorMarks, tempoMarks: currSettings.tempoMarks })
+
+      alert("Combined text copied to clipboard!");
+    } else if (type === "transposes") {
+      const text = generateCombinedTransposes(ctx.getSelectedSheets());
+      navigator.clipboard.writeText(text);
+      alert("Transposes copied to clipboard!");
+    }
+  } catch (err) {
+    console.error("Combining failed", err);
+    alert("Combining failed: " + err.message);
+  } finally {
+    ctx.setChordsAndOtherwise(originalData);
+    ctx.setFilename(originalFilename);
+    ctx.setSheetReady(originalSheetReady);
+    ctx.updateSettings(originalSettings);
+
+    if (!originalSheetReady) ctx.importer.show();
+    ctx.setIsHistoryMultiSelect(true);
+    ctx.HistoryCombineDialogComp.setBusy(false);
+  }
+}

--- a/src/utils/Settings.js
+++ b/src/utils/Settings.js
@@ -1,0 +1,36 @@
+export const fonts = [
+  "Verdana",
+  "Tahoma",
+  "Dejavu Sans",
+  "Segoe UI",
+  "Helvetica",
+  "Lucida Console",
+  "Candara",
+];
+
+export const getDefaultSettings = () => ({
+  beats: 4,
+  breaks: "realistic",
+  quantize: 35,
+  classicChordOrder: false,
+  sequentialQuantize: true,
+  curlyQuantizes: true,
+  pShifts: "Start",
+  pOors: "Inorder",
+  oors: true,
+  tempoMarks: false,
+  oorMarks: false,
+  bpmChanges: true,
+  bpmType: "detailed",
+  minSpeedChange: 10,
+  oorSeparator: ":",
+  resilience: 2,
+  stickyAutoTransposition: false,
+  font: fonts[0],
+  lineHeight: 135,
+  capturingImage: false,
+  missingTempo: false,
+  bpm: 120,
+  tracks: [{}], // populated from main, default = all selected
+  ...JSON.parse(localStorage.getItem("preferences") || "{}"),
+});


### PR DESCRIPTION
Allows combining sheets taking into account their:

1. transpose values (to prevent duplicate transpose comments in text/images, calculate relative differences)
2. transpose index (to ensure that the index increments correctly in a combined sheet always)
3. timing (self-explanatory)
4. size of the sheets (particularly for image capture)

Also fixes some bugs like export and delete not working, storage being too full to open a split sheet in a new window, preventing copying of image to clipboard if it will cause the app to crash due to browser clipboard limits.

I also had to make some of the code reusable, such as the sidebar settings found beside sheets to be used for combination settings as well, and allowing a way to use methods/objects from App.svelte easily in other files.